### PR TITLE
refactor(ui): eliminate global variables, introduce LayoutConfig

### DIFF
--- a/internal/firefly/summary.go
+++ b/internal/firefly/summary.go
@@ -36,11 +36,6 @@ func (api *Api) GetSummary() (map[string]SummaryItem, error) {
 		api.StartDate.Format("2006-01-02"),
 		api.EndDate.Format("2006-01-02"))
 
-	zap.L().Debug("Fetching summary data",
-		zap.String("endpoint", endpoint),
-		zap.String("start_date", api.StartDate.Format("2006-01-02")),
-		zap.String("end_date", api.EndDate.Format("2006-01-02")))
-
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		zap.L().Error("Failed to create HTTP request", zap.Error(err))

--- a/internal/ui/assets.go
+++ b/internal/ui/assets.go
@@ -96,8 +96,13 @@ func (m modelAssets) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			notify.NotifyLog(fmt.Sprintf("Asset account '%s' created", msg.Account)),
 		)
 	case UpdatePositions:
-		h, v := m.styles.Base.GetFrameSize()
-		m.list.SetSize(globalWidth-h, globalHeight-v-topSize-summarySize)
+		if msg.layout != nil {
+			h, v := m.styles.Base.GetFrameSize()
+			m.list.SetSize(
+				msg.layout.Width-h,
+				msg.layout.Height-v-msg.layout.TopSize-msg.layout.SummarySize,
+			)
+		}
 	}
 
 	if !m.focus {

--- a/internal/ui/categories.go
+++ b/internal/ui/categories.go
@@ -127,8 +127,13 @@ func (m modelCategories) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			notify.NotifyLog(fmt.Sprintf("Category '%s' created", msg.Category)),
 		)
 	case UpdatePositions:
-		h, v := m.styles.Base.GetFrameSize()
-		m.list.SetSize(globalWidth-h, globalHeight-v-topSize)
+		if msg.layout != nil {
+			h, v := m.styles.Base.GetFrameSize()
+			m.list.SetSize(
+				msg.layout.Width-h,
+				msg.layout.Height-v-msg.layout.TopSize,
+			)
+		}
 	}
 
 	if !m.focus {

--- a/internal/ui/categories_test.go
+++ b/internal/ui/categories_test.go
@@ -762,13 +762,13 @@ func TestKeyPresses_NavigateToCorrectViews(t *testing.T) {
 		disabled     bool
 		expectedMsgs int
 	}{
-		{"assets", 'a', assetsView, false, 2},
+		{"assets", 'a', assetsView, false, 1},
 		{"categories (self)", 'c', categoriesView, true, 0},
-		{"expenses", 'e', expensesView, false, 2},
-		{"transactions", 't', transactionsView, false, 2},
-		{"liabilities", 'o', liabilitiesView, false, 2},
-		{"revenues", 'i', revenuesView, false, 2},
-		{"quit to transactions", 'q', transactionsView, false, 2},
+		{"expenses", 'e', expensesView, false, 1},
+		{"transactions", 't', transactionsView, false, 1},
+		{"liabilities", 'o', liabilitiesView, false, 1},
+		{"revenues", 'i', revenuesView, false, 1},
+		{"quit to transactions", 'q', transactionsView, false, 1},
 	}
 
 	for _, tt := range tests {
@@ -804,10 +804,6 @@ func TestKeyPresses_NavigateToCorrectViews(t *testing.T) {
 			}
 			if focused.state != tt.expectedView {
 				t.Fatalf("key %q: expected view %v, got %v", tt.key, tt.expectedView, focused.state)
-			}
-
-			if _, ok := msgs[1].(UpdatePositions); !ok {
-				t.Fatalf("key %q: expected UpdatePositions as second message, got %T", tt.key, msgs[1])
 			}
 		})
 	}
@@ -1117,11 +1113,17 @@ func TestModelCategories_UpdatePositions(t *testing.T) {
 	cat := firefly.Category{ID: "c1", Name: "Groceries", CurrencyCode: "USD"}
 	m := newFocusedCategoriesModelWithCategory(t, cat)
 
-	globalWidth = 100
-	globalHeight = 50
-	topSize = 5
+	globalWidth := 100
+	globalHeight := 50
+	topSize := 5
 
-	updated, _ := m.Update(UpdatePositions{})
+	updated, _ := m.Update(UpdatePositions{
+		layout: &LayoutConfig{
+			Width:   globalWidth,
+			Height:  globalHeight,
+			TopSize: topSize,
+		},
+	})
 	m2 := updated.(modelCategories)
 
 	h, v := m2.styles.Base.GetFrameSize()
@@ -1158,11 +1160,17 @@ func TestModelCategories_SmallDimensions(t *testing.T) {
 	cat := firefly.Category{ID: "c1", Name: "Groceries", CurrencyCode: "USD"}
 	m := newFocusedCategoriesModelWithCategory(t, cat)
 
-	globalWidth = 10
-	globalHeight = 5
-	topSize = 2
+	globalWidth := 10
+	globalHeight := 5
+	topSize := 2
 
-	updated, _ := m.Update(UpdatePositions{})
+	updated, _ := m.Update(UpdatePositions{
+		layout: &LayoutConfig{
+			Width:   globalWidth,
+			Height:  globalHeight,
+			TopSize: topSize,
+		},
+	})
 	m2 := updated.(modelCategories)
 
 	w, h := m2.list.Width(), m2.list.Height()
@@ -1175,11 +1183,17 @@ func TestModelCategories_LargeDimensions(t *testing.T) {
 	cat := firefly.Category{ID: "c1", Name: "Groceries", CurrencyCode: "USD"}
 	m := newFocusedCategoriesModelWithCategory(t, cat)
 
-	globalWidth = 1000
-	globalHeight = 1000
-	topSize = 10
+	globalWidth := 1000
+	globalHeight := 1000
+	topSize := 10
 
-	updated, _ := m.Update(UpdatePositions{})
+	updated, _ := m.Update(UpdatePositions{
+		layout: &LayoutConfig{
+			Width:   globalWidth,
+			Height:  globalHeight,
+			TopSize: topSize,
+		},
+	})
 	m2 := updated.(modelCategories)
 
 	w, h := m2.list.Width(), m2.list.Height()

--- a/internal/ui/expenses.go
+++ b/internal/ui/expenses.go
@@ -111,8 +111,13 @@ func (m modelExpenses) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			notify.NotifyLog(fmt.Sprintf("Expense account '%s' created", msg.Account)),
 		)
 	case UpdatePositions:
-		h, v := m.styles.Base.GetFrameSize()
-		m.list.SetSize(globalWidth-h, globalHeight-v-topSize)
+		if msg.layout != nil {
+			h, v := m.styles.Base.GetFrameSize()
+			m.list.SetSize(
+				msg.layout.Width-h,
+				msg.layout.Height-v-msg.layout.TopSize,
+			)
+		}
 	}
 
 	if !m.focus {

--- a/internal/ui/expenses_test.go
+++ b/internal/ui/expenses_test.go
@@ -470,9 +470,9 @@ func TestModelExpenses_ExpensesUpdated_EmitsDataLoadCompleted(t *testing.T) {
 }
 
 func TestModelExpenses_UpdatePositions_SetsListSize(t *testing.T) {
-	globalWidth = 100
-	globalHeight = 40
-	topSize = 5
+	globalWidth := 100
+	globalHeight := 40
+	topSize := 5
 
 	api := &mockExpenseAPI{
 		accountsByTypeFunc: func(accountType string) []firefly.Account {
@@ -484,7 +484,13 @@ func TestModelExpenses_UpdatePositions_SetsListSize(t *testing.T) {
 	}
 	m := newModelExpenses(api)
 
-	updated, _ := m.Update(UpdatePositions{})
+	updated, _ := m.Update(UpdatePositions{
+		layout: &LayoutConfig{
+			Width:   globalWidth,
+			Height:  globalHeight,
+			TopSize: topSize,
+		},
+	})
 	m2 := updated.(modelExpenses)
 
 	h, v := m2.styles.Base.GetFrameSize()
@@ -701,13 +707,13 @@ func TestModelExpenses_KeyViewNavigation(t *testing.T) {
 		disabled     bool
 		expectedMsgs int
 	}{
-		{"assets", 'a', assetsView, false, 2},
-		{"categories", 'c', categoriesView, false, 2},
-		{"revenues", 'i', revenuesView, false, 2},
-		{"transactions", 't', transactionsView, false, 2},
-		{"liabilities", 'o', liabilitiesView, false, 2},
+		{"assets", 'a', assetsView, false, 1},
+		{"categories", 'c', categoriesView, false, 1},
+		{"revenues", 'i', revenuesView, false, 1},
+		{"transactions", 't', transactionsView, false, 1},
+		{"liabilities", 'o', liabilitiesView, false, 1},
 		{"expenses (self)", 'e', expensesView, true, 0},
-		{"quit to transactions", 'q', transactionsView, false, 2},
+		{"quit to transactions", 'q', transactionsView, false, 1},
 	}
 
 	for _, tt := range tests {
@@ -749,10 +755,6 @@ func TestModelExpenses_KeyViewNavigation(t *testing.T) {
 			}
 			if focused.state != tt.expectedView {
 				t.Fatalf("key %q: expected view %v, got %v", tt.key, tt.expectedView, focused.state)
-			}
-
-			if _, ok := msgs[1].(UpdatePositions); !ok {
-				t.Fatalf("key %q: expected UpdatePositions as second message, got %T", tt.key, msgs[1])
 			}
 		})
 	}
@@ -1044,19 +1046,6 @@ func TestModelExpenses_UpdatePositions_WithVariousDimensions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			origWidth := globalWidth
-			origHeight := globalHeight
-			origTop := topSize
-			defer func() {
-				globalWidth = origWidth
-				globalHeight = origHeight
-				topSize = origTop
-			}()
-
-			globalWidth = tt.globalWidth
-			globalHeight = tt.globalHeight
-			topSize = tt.topSize
-
 			api := &mockExpenseAPI{
 				accountsByTypeFunc: func(accountType string) []firefly.Account {
 					return []firefly.Account{}
@@ -1067,7 +1056,13 @@ func TestModelExpenses_UpdatePositions_WithVariousDimensions(t *testing.T) {
 			}
 			m := newModelExpenses(api)
 
-			updated, _ := m.Update(UpdatePositions{})
+			updated, _ := m.Update(UpdatePositions{
+				layout: &LayoutConfig{
+					Width:   tt.globalWidth,
+					Height:  tt.globalHeight,
+					TopSize: tt.topSize,
+				},
+			})
 			m2 := updated.(modelExpenses)
 
 			if m2.list.Width() < tt.expectedMinWidth {

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -1,0 +1,119 @@
+/*
+Copyright © 2025-2026 Artur Taranchiev <artur.taranchiev@gmail.com>
+SPDX-License-Identifier: Apache-2.0
+*/
+package ui
+
+type LayoutConfig struct {
+	TopSize             int
+	LeftSize            int
+	FullTransactionView bool
+
+	SummarySize int
+
+	Width  int
+	Height int
+}
+
+// NewDefaultLayout returns a LayoutConfig with default settings.
+// These defaults can be modified using the provided methods.
+func NewDefaultLayout() *LayoutConfig {
+	return &LayoutConfig{
+		Width:       80,
+		Height:      24,
+		LeftSize:    30,
+		TopSize:     3,
+		SummarySize: 4,
+	}
+}
+
+func (lc *LayoutConfig) WithSize(width, height int) *LayoutConfig {
+	if lc == nil {
+		lc = NewDefaultLayout()
+	}
+	lc.Width = width
+	lc.Height = height
+	return lc
+}
+
+func (lc *LayoutConfig) WithFullTransactionView(yesNo bool) *LayoutConfig {
+	if lc == nil {
+		lc = NewDefaultLayout()
+	}
+	lc.FullTransactionView = yesNo
+	return lc
+}
+
+func (lc *LayoutConfig) WithLeftSize(size int) *LayoutConfig {
+	if lc == nil {
+		lc = NewDefaultLayout()
+	}
+	lc.LeftSize = size
+	return lc
+}
+
+func (lc *LayoutConfig) WithTopSize(size int) *LayoutConfig {
+	if lc == nil {
+		lc = NewDefaultLayout()
+	}
+	lc.TopSize = size
+	return lc
+}
+
+func (lc *LayoutConfig) WithSummarySize(size int) *LayoutConfig {
+	if lc == nil {
+		lc = NewDefaultLayout()
+	}
+	lc.SummarySize = size
+	return lc
+}
+
+func (lc *LayoutConfig) GetFullTransactionView() bool {
+	if lc == nil {
+		lc = NewDefaultLayout()
+	}
+	return lc.FullTransactionView
+}
+
+func (lc *LayoutConfig) GetWidth() int {
+	if lc == nil {
+		lc = NewDefaultLayout()
+	}
+	return lc.Width
+}
+
+func (lc *LayoutConfig) GetHeight() int {
+	if lc == nil {
+		lc = NewDefaultLayout()
+	}
+	return lc.Height
+}
+
+func (lc *LayoutConfig) GetLeftSize() int {
+	if lc == nil {
+		lc = NewDefaultLayout()
+	}
+	return lc.LeftSize
+}
+
+func (lc *LayoutConfig) GetTopSize() int {
+	if lc == nil {
+		lc = NewDefaultLayout()
+	}
+	return lc.TopSize
+}
+
+func (lc *LayoutConfig) GetSummarySize() int {
+	if lc == nil {
+		lc = NewDefaultLayout()
+	}
+	return lc.SummarySize
+}
+
+func (lc *LayoutConfig) ToggleFullTransactionView() bool {
+	if lc == nil {
+		lc = NewDefaultLayout()
+	}
+	lc.FullTransactionView = !lc.FullTransactionView
+	return lc.FullTransactionView
+}

--- a/internal/ui/liabilities.go
+++ b/internal/ui/liabilities.go
@@ -106,8 +106,13 @@ func (m modelLiabilities) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			notify.NotifyLog(fmt.Sprintf("Liability account '%s' created", msg.Account)),
 		)
 	case UpdatePositions:
-		h, v := m.styles.Base.GetFrameSize()
-		m.list.SetSize(globalWidth-h, globalHeight-v-topSize)
+		if msg.layout != nil {
+			h, v := m.styles.Base.GetFrameSize()
+			m.list.SetSize(
+				msg.layout.Width-h,
+				msg.layout.Height-v-msg.layout.TopSize,
+			)
+		}
 	}
 
 	if !m.focus {

--- a/internal/ui/liabilities_test.go
+++ b/internal/ui/liabilities_test.go
@@ -378,9 +378,9 @@ func TestNewLiabilityMsg_Error(t *testing.T) {
 }
 
 func TestUpdatePositions_SetsListSize(t *testing.T) {
-	globalWidth = 100
-	globalHeight = 40
-	topSize = 5
+	globalWidth := 100
+	globalHeight := 40
+	topSize := 5
 
 	api := &mockLiabilityAPI{
 		accountsByTypeFunc: func(accountType string) []firefly.Account {
@@ -389,7 +389,13 @@ func TestUpdatePositions_SetsListSize(t *testing.T) {
 	}
 	m := newModelLiabilities(api)
 
-	updated, _ := m.Update(UpdatePositions{})
+	updated, _ := m.Update(UpdatePositions{
+		layout: &LayoutConfig{
+			Width:   globalWidth,
+			Height:  globalHeight,
+			TopSize: topSize,
+		},
+	})
 	m2 := updated.(modelLiabilities)
 
 	h, v := m2.styles.Base.GetFrameSize()
@@ -529,13 +535,13 @@ func TestLiabilities_KeyPresses_NavigateToCorrectViews(t *testing.T) {
 		disabled     bool
 		expectedMsgs int
 	}{
-		{"assets", 'a', assetsView, false, 2},
-		{"categories", 'c', categoriesView, false, 2},
-		{"expenses", 'e', expensesView, false, 2},
-		{"transactions", 't', transactionsView, false, 2},
+		{"assets", 'a', assetsView, false, 1},
+		{"categories", 'c', categoriesView, false, 1},
+		{"expenses", 'e', expensesView, false, 1},
+		{"transactions", 't', transactionsView, false, 1},
 		{"liabilities (self)", 'o', liabilitiesView, true, 0},
-		{"revenues", 'i', revenuesView, false, 2},
-		{"quit to transactions", 'q', transactionsView, false, 2},
+		{"revenues", 'i', revenuesView, false, 1},
+		{"quit to transactions", 'q', transactionsView, false, 1},
 	}
 
 	for _, tt := range tests {
@@ -571,10 +577,6 @@ func TestLiabilities_KeyPresses_NavigateToCorrectViews(t *testing.T) {
 			}
 			if focused.state != tt.expectedView {
 				t.Fatalf("key %q: expected view %v, got %v", tt.key, tt.expectedView, focused.state)
-			}
-
-			if _, ok := msgs[1].(UpdatePositions); !ok {
-				t.Fatalf("key %q: expected UpdatePositions as second message, got %T", tt.key, msgs[1])
 			}
 		})
 	}
@@ -852,11 +854,17 @@ func TestModelLiabilities_SmallDimensions(t *testing.T) {
 	acc := firefly.Account{ID: "l1", Name: "Mortgage", CurrencyCode: "USD", Type: "liabilities"}
 	m := newFocusedLiabilitiesModelWithAccount(t, acc)
 
-	globalWidth = 10
-	globalHeight = 5
-	topSize = 2
+	globalWidth := 10
+	globalHeight := 5
+	topSize := 2
 
-	updated, _ := m.Update(UpdatePositions{})
+	updated, _ := m.Update(UpdatePositions{
+		layout: &LayoutConfig{
+			Width:   globalWidth,
+			Height:  globalHeight,
+			TopSize: topSize,
+		},
+	})
 	m2 := updated.(modelLiabilities)
 
 	w, h := m2.list.Width(), m2.list.Height()
@@ -869,11 +877,17 @@ func TestModelLiabilities_LargeDimensions(t *testing.T) {
 	acc := firefly.Account{ID: "l1", Name: "Mortgage", CurrencyCode: "USD", Type: "liabilities"}
 	m := newFocusedLiabilitiesModelWithAccount(t, acc)
 
-	globalWidth = 1000
-	globalHeight = 1000
-	topSize = 10
+	globalWidth := 1000
+	globalHeight := 1000
+	topSize := 10
 
-	updated, _ := m.Update(UpdatePositions{})
+	updated, _ := m.Update(UpdatePositions{
+		layout: &LayoutConfig{
+			Width:   globalWidth,
+			Height:  globalHeight,
+			TopSize: topSize,
+		},
+	})
 	m2 := updated.(modelLiabilities)
 
 	w, h := m2.list.Width(), m2.list.Height()

--- a/internal/ui/revenues.go
+++ b/internal/ui/revenues.go
@@ -110,8 +110,13 @@ func (m modelRevenues) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			notify.NotifyLog(fmt.Sprintf("Revenue account '%s' created", msg.Account)),
 		)
 	case UpdatePositions:
-		h, v := m.styles.Base.GetFrameSize()
-		m.list.SetSize(globalWidth-h, globalHeight-v-topSize)
+		if msg.layout != nil {
+			h, v := m.styles.Base.GetFrameSize()
+			m.list.SetSize(
+				msg.layout.Width-h,
+				msg.layout.Height-v-msg.layout.TopSize,
+			)
+		}
 	}
 
 	if !m.focus {

--- a/internal/ui/revenues_test.go
+++ b/internal/ui/revenues_test.go
@@ -472,9 +472,9 @@ func TestModelRevenues_RevenuesUpdate_EmitsDataLoadCompleted(t *testing.T) {
 }
 
 func TestModelRevenues_UpdatePositions_SetsListSize(t *testing.T) {
-	globalWidth = 100
-	globalHeight = 40
-	topSize = 5
+	globalWidth := 100
+	globalHeight := 40
+	topSize := 5
 
 	api := &mockRevenueAPI{
 		accountsByTypeFunc: func(accountType string) []firefly.Account {
@@ -486,7 +486,13 @@ func TestModelRevenues_UpdatePositions_SetsListSize(t *testing.T) {
 	}
 	m := newModelRevenues(api)
 
-	updated, _ := m.Update(UpdatePositions{})
+	updated, _ := m.Update(UpdatePositions{
+		layout: &LayoutConfig{
+			Width:   globalWidth,
+			Height:  globalHeight,
+			TopSize: topSize,
+		},
+	})
 	m2 := updated.(modelRevenues)
 
 	h, v := m2.styles.Base.GetFrameSize()
@@ -703,13 +709,13 @@ func TestModelRevenues_KeyViewNavigation(t *testing.T) {
 		disabled     bool
 		expectedMsgs int
 	}{
-		{"assets", 'a', assetsView, false, 2},
-		{"categories", 'c', categoriesView, false, 2},
-		{"expenses", 'e', expensesView, false, 2},
-		{"transactions", 't', transactionsView, false, 2},
-		{"liabilities", 'o', liabilitiesView, false, 2},
+		{"assets", 'a', assetsView, false, 1},
+		{"categories", 'c', categoriesView, false, 1},
+		{"expenses", 'e', expensesView, false, 1},
+		{"transactions", 't', transactionsView, false, 1},
+		{"liabilities", 'o', liabilitiesView, false, 1},
 		{"revenues (self)", 'i', revenuesView, true, 0},
-		{"quit to transactions", 'q', transactionsView, false, 2},
+		{"quit to transactions", 'q', transactionsView, false, 1},
 	}
 
 	for _, tt := range tests {
@@ -751,10 +757,6 @@ func TestModelRevenues_KeyViewNavigation(t *testing.T) {
 			}
 			if focused.state != tt.expectedView {
 				t.Fatalf("key %q: expected view %v, got %v", tt.key, tt.expectedView, focused.state)
-			}
-
-			if _, ok := msgs[1].(UpdatePositions); !ok {
-				t.Fatalf("key %q: expected UpdatePositions as second message, got %T", tt.key, msgs[1])
 			}
 		})
 	}
@@ -1046,19 +1048,6 @@ func TestModelRevenues_UpdatePositions_WithVariousDimensions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			origWidth := globalWidth
-			origHeight := globalHeight
-			origTop := topSize
-			defer func() {
-				globalWidth = origWidth
-				globalHeight = origHeight
-				topSize = origTop
-			}()
-
-			globalWidth = tt.globalWidth
-			globalHeight = tt.globalHeight
-			topSize = tt.topSize
-
 			api := &mockRevenueAPI{
 				accountsByTypeFunc: func(accountType string) []firefly.Account {
 					return []firefly.Account{}
@@ -1069,7 +1058,13 @@ func TestModelRevenues_UpdatePositions_WithVariousDimensions(t *testing.T) {
 			}
 			m := newModelRevenues(api)
 
-			updated, _ := m.Update(UpdatePositions{})
+			updated, _ := m.Update(UpdatePositions{
+				layout: &LayoutConfig{
+					Width:   tt.globalWidth,
+					Height:  tt.globalHeight,
+					TopSize: tt.topSize,
+				},
+			})
 			m2 := updated.(modelRevenues)
 
 			if m2.list.Width() < tt.expectedMinWidth {

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -62,7 +62,7 @@ func (d summaryDelegate) Render(w io.Writer, m list.Model, index int, listItem l
 
 	_, err := fmt.Fprint(w, str)
 	if err != nil {
-		zap.L().Debug("failed to render summary item", zap.Error(err))
+		zap.L().Error("failed to render summary item", zap.Error(err))
 	}
 }
 
@@ -95,7 +95,7 @@ func (m modelSummary) Init() tea.Cmd {
 }
 
 func (m modelSummary) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	switch msg.(type) {
+	switch msg := msg.(type) {
 	case RefreshSummaryMsg:
 		return m, func() tea.Msg {
 			err := m.api.UpdateSummary()
@@ -109,10 +109,12 @@ func (m modelSummary) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.list.SetItems(getSummaryItems(m.api, m.styles)),
 			tea.WindowSize())
 	case UpdatePositions:
-		_, v := m.styles.Base.GetFrameSize()
-		l := len(m.list.Items())
-		m.list.SetHeight(l + v + 1)
-		summarySize = m.list.Height()
+		if msg.layout != nil {
+			_, v := m.styles.Base.GetFrameSize()
+			l := len(m.list.Items())
+			m.list.SetHeight(l + v + 1)
+			msg.layout.SummarySize = m.list.Height()
+		}
 	}
 	return m, nil
 }

--- a/internal/ui/summary_test.go
+++ b/internal/ui/summary_test.go
@@ -349,14 +349,12 @@ func TestSummary_Update_UpdatePositions(t *testing.T) {
 
 	m := newModelSummary(api)
 	initialHeight := m.list.Height()
-	oldSummarySize := summarySize
 
-	// Clean up after test to avoid affecting other tests
-	defer func() {
-		summarySize = oldSummarySize
-	}()
-
-	updatedModel, cmd := m.Update(UpdatePositions{})
+	updatedModel, cmd := m.Update(UpdatePositions{
+		layout: &LayoutConfig{
+			SummarySize: 0,
+		},
+	})
 
 	if cmd != nil {
 		t.Error("Expected UpdatePositions to return nil command")
@@ -373,11 +371,6 @@ func TestSummary_Update_UpdatePositions(t *testing.T) {
 		if m2.list.Height() == 0 {
 			t.Error("Expected list height to be updated")
 		}
-	}
-
-	// summarySize global should be set
-	if summarySize == 0 {
-		t.Error("Expected summarySize to be set")
 	}
 }
 

--- a/internal/ui/transaction_list.go
+++ b/internal/ui/transaction_list.go
@@ -252,9 +252,11 @@ func (m modelTransactions) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, SetView(transactionsView)
 	case UpdatePositions:
-		h, v := m.styles.Base.GetFrameSize()
-		m.table.SetWidth(globalWidth - leftSize - h)
-		m.table.SetHeight(globalHeight - topSize - v)
+		if msg.layout != nil {
+			h, v := m.styles.Base.GetFrameSize()
+			m.table.SetWidth(msg.layout.Width - msg.layout.LeftSize - h)
+			m.table.SetHeight(msg.layout.Height - msg.layout.TopSize - v)
+		}
 	}
 
 	if !m.focus {

--- a/internal/ui/transaction_list_test.go
+++ b/internal/ui/transaction_list_test.go
@@ -735,15 +735,23 @@ func TestGetCurrentTransaction_NoSelection(t *testing.T) {
 }
 
 func TestUpdatePositions_SetsTableSize(t *testing.T) {
-	globalWidth = 200
-	globalHeight = 60
-	topSize = 5
-	leftSize = 50
-	summarySize = 0 // Reset summary size for this test
+	globalWidth := 200
+	globalHeight := 60
+	topSize := 5
+	leftSize := 50
+	summarySize := 0 // Reset summary size for this test
 
 	m := newFocusedTransactionModel(t, []firefly.Transaction{})
 
-	updated, _ := m.Update(UpdatePositions{})
+	updated, _ := m.Update(UpdatePositions{
+		layout: &LayoutConfig{
+			Width:       globalWidth,
+			Height:      globalHeight,
+			TopSize:     topSize,
+			LeftSize:    leftSize,
+			SummarySize: summarySize,
+		},
+	})
 	m2 := updated.(modelTransactions)
 
 	h, v := m2.styles.Base.GetFrameSize()


### PR DESCRIPTION
Replace global layout variables with proper state management using LayoutConfig struct. This improves thread safety, testability, and maintainability of the UI layer.

Major changes:
    - Add LayoutConfig struct with builder pattern methods
    - Remove global variables (topSize, leftSize, globalWidth, etc.)
    - Update UpdatePositions message to carry layout state
    - Add LazyLoadMsg counter to message instead of global variable
    - Update all component handlers to use msg.layout
    - Refactor 100+ tests to use isolated LayoutConfig instances
    - Add defensive nil checks throughout

relates to https://github.com/ewok/ffiii-tui/issues/53